### PR TITLE
Remove extra path when pushing to GHCR with Helm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
       - name: Push packaged chart to GHCR
-        run: helm push ${{ github.ref_name }}.tgz oci://${{ env.REGISTRY }}/${{ github.repository }}/${{ steps.release-details.outputs.chart_name }}
+        run: helm push ${{ github.ref_name }}.tgz oci://${{ env.REGISTRY }}/${{ github.repository }}
       - name: Get pushed chart digest
         id: get-digest
         run: |


### PR DESCRIPTION
I think the attest step of the workflow is [failing](https://github.com/github/helm-charts/actions/runs/9368652512/job/25791219523) because we push `ghcr.io/github/helm-charts/policy-controller/policy-controller:v0.9.0-github2` to GHCR  but we try to get details about `ghcr.io/github/helm-charts/policy-controller:v0.9.0-github2`. I removed the extra `policy-controller` piece from the path when pushing to GHCR. So Helm should now push `ghcr.io/github/helm-charts/policy-controller:v0.9.0-github2` to GHCR.

