### PR TITLE
Fix subject name in attest step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,6 @@ jobs:
       - name: Attest
         uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ github.repository }}/${{ github.ref_name }}.tgz 
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository }}/${{ steps.release-details.outputs.chart_name }}
           subject-digest: ${{ steps.get-digest.outputs.digest }}
           push-to-registry: true


### PR DESCRIPTION
The subject name must equal the OCI registry path (sans digest) according to the [attest-build-provenance readme](https://github.com/actions/attest-build-provenance/?tab=readme-ov-file#container-image).

Signed-off-by: Cody Soyland <codysoyland@github.com>