### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @github/package-security-eng @steiza


### PR DESCRIPTION
Part of  https://github.com/github/package-security/issues/1788

Add CODEOWNERS in preparation for open sourcing this repository.
