### PR TITLE
Remove name from reusable workflow call

### DIFF
--- a/.github/workflows/policies-release.yml
+++ b/.github/workflows/policies-release.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   release-policy-controller:
-    name: Release Policy Controller Policies Chart
     uses: ./github/workflows/release.yml
     with:
       chart_name: policy-controller-policies

--- a/.github/workflows/policy-controller-release.yml
+++ b/.github/workflows/policy-controller-release.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   release-policy-controller:
-    name: Release Policy Controller Chart
     uses: ./github/workflows/release.yml
     with:
       chart_name: policy-controller


### PR DESCRIPTION
We need to remove the name field if calling a reusable workflow.