### PR TITLE
use ref_name instead of ref when cutting a release

### DIFF
--- a/.github/workflows/policies-release.yml
+++ b/.github/workflows/policies-release.yml
@@ -10,7 +10,7 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       chart_name: policy-controller-policies
-      chart_release: ${{ github.ref }}
+      chart_release: ${{ github.ref_name }}
     permissions:
       attestations: write
       contents: read

--- a/.github/workflows/policy-controller-release.yml
+++ b/.github/workflows/policy-controller-release.yml
@@ -10,7 +10,7 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       chart_name: policy-controller
-      chart_release: ${{ github.ref }}
+      chart_release: ${{ github.ref_name }}
     permissions:
       attestations: write
       contents: read


### PR DESCRIPTION
We want to use `ref_name`, which is just the tag name like "policy-controller-v1.2.3", instead of `ref`, which is "refs/tags/policy-controller-v1.2.3"