### PR TITLE
include version when pushing helm package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push packaged chart to GHCR
-        run: helm push ${{ inputs.chart_name }}.tgz oci://${{ env.REGISTRY }}/${{ github.repository }}
+        run: helm push ${{ inputs.chart_name }}-${{ steps.release-details.outputs.release_version }}.tgz oci://${{ env.REGISTRY }}/${{ github.repository }}
       - uses: imjasonh/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # v0.3
       - name: Get pushed chart digest
         id: get-digest


### PR DESCRIPTION
The package version needs to be included when pushing a package to Helm.