### PR TITLE
add default url for gh fulcio

### DIFF
--- a/charts/trust-policies/templates/clusterimagepolicy-github.yaml
+++ b/charts/trust-policies/templates/clusterimagepolicy-github.yaml
@@ -9,6 +9,7 @@ spec:
   authorities:
   - keyless:
       trustRootRef: github
+      url: https://fulcio.githubapp.com
       identities:
       - issuer: https://token.actions.githubusercontent.com
         subjectRegExp: https://github.com/{{ .Values.policy.organization }}/{{ .Values.policy.repo }}/\.github/workflows/.*


### PR DESCRIPTION
Updates the clusterimagepolicy with the default URL for the GitHub Fulcio instance. 

I noticed that when this policy is applied to the cluster, the `url` field is defaulted to a value of "https://fulcio.sigstore.dev" which could be confusing to users given that we're creating a policy which references the GH Fulcio instance.

<img width="637" alt="image" src="https://github.com/user-attachments/assets/021bb76a-2be4-4534-bc0f-74eb149ec21c">

It doesn't appear that having the wrong value here has an impact on the policy itself, but it could still be confusing to any user who inspects it.