### PR TITLE
add public-good to default policy

### DIFF
--- a/charts/trust-policies/Chart.yaml
+++ b/charts/trust-policies/Chart.yaml
@@ -8,8 +8,8 @@ sources:
 type: application
 
 name: trust-policies
-version: "v0.2.0"
-appVersion: "v0.2.0"
+version: "v0.3.0"
+appVersion: "v0.3.0"
 
 maintainers:
   - name: codysoyland

--- a/charts/trust-policies/templates/clusterimagepolicy-github.yaml
+++ b/charts/trust-policies/templates/clusterimagepolicy-github.yaml
@@ -7,7 +7,8 @@ spec:
   images:
   - glob: "**"
   authorities:
-  - keyless:
+  - name: github
+    keyless:
       trustRootRef: github
       identities:
       - issuer: https://token.actions.githubusercontent.com
@@ -18,4 +19,15 @@ spec:
     attestations:
     - name: require-attestation
       predicateType: {{ .Values.policy.predicateType }}
+  - name: public-good
+    keyless:
+      identities:
+      - issuer: https://token.actions.githubusercontent.com
+        subjectRegExp: https://github.com/bdehamer/.*/\.github/workflows/.*
+    ctlog:
+      url: https://rekor.sigstore.dev
+    signatureFormat: bundle
+    attestations:
+    - name: require-attestation
+      predicateType: https://slsa.dev/provenance/v1
 {{- end }}

--- a/charts/trust-policies/templates/clusterimagepolicy-github.yaml
+++ b/charts/trust-policies/templates/clusterimagepolicy-github.yaml
@@ -23,11 +23,11 @@ spec:
     keyless:
       identities:
       - issuer: https://token.actions.githubusercontent.com
-        subjectRegExp: https://github.com/bdehamer/.*/\.github/workflows/.*
+        subjectRegExp: https://github.com/{{ .Values.policy.organization }}/{{ .Values.policy.repo }}/\.github/workflows/.*
     ctlog:
       url: https://rekor.sigstore.dev
     signatureFormat: bundle
     attestations:
     - name: require-attestation
-      predicateType: https://slsa.dev/provenance/v1
+      predicateType: {{ .Values.policy.predicateType }}
 {{- end }}

--- a/charts/trust-policies/templates/clusterimagepolicy-github.yaml
+++ b/charts/trust-policies/templates/clusterimagepolicy-github.yaml
@@ -7,7 +7,7 @@ spec:
   images:
   - glob: "**"
   authorities:
-{{ if .Values.trust.github }}
+{{ if .Values.policy.trust.github }}
   - name: github
     keyless:
       trustRootRef: github
@@ -20,7 +20,7 @@ spec:
     attestations:
     - name: require-attestation
       predicateType: {{ .Values.policy.predicateType }}
-{{ end }}{{ if .Values.trust.sigstorePublic }}
+{{ end }}{{ if .Values.policy.trust.sigstorePublic }}
   - name: public-good
     keyless:
       identities:

--- a/charts/trust-policies/templates/clusterimagepolicy-github.yaml
+++ b/charts/trust-policies/templates/clusterimagepolicy-github.yaml
@@ -7,6 +7,7 @@ spec:
   images:
   - glob: "**"
   authorities:
+{{ if .Values.trust.github }}
   - name: github
     keyless:
       trustRootRef: github
@@ -19,6 +20,7 @@ spec:
     attestations:
     - name: require-attestation
       predicateType: {{ .Values.policy.predicateType }}
+{{ end }}{{ if .Values.trust.sigstorePublic }}
   - name: public-good
     keyless:
       identities:
@@ -30,4 +32,5 @@ spec:
     attestations:
     - name: require-attestation
       predicateType: {{ .Values.policy.predicateType }}
+{{ end }}
 {{- end }}

--- a/charts/trust-policies/values.yaml
+++ b/charts/trust-policies/values.yaml
@@ -8,3 +8,10 @@ policy:
   enabled: false
   # predicateType is the type of predicate to expect in the default policy
   predicateType: https://slsa.dev/provenance/v1
+
+# Identify which signing authorities should be trusted as part of the policy
+trust:
+  # trust the GitHub signing authority
+  github: true
+  # trust the Sigstore public-good signing authority
+  sigstorePublic: true

--- a/charts/trust-policies/values.yaml
+++ b/charts/trust-policies/values.yaml
@@ -8,10 +8,9 @@ policy:
   enabled: false
   # predicateType is the type of predicate to expect in the default policy
   predicateType: https://slsa.dev/provenance/v1
-
-# Identify which signing authorities should be trusted as part of the policy
-trust:
-  # trust the GitHub signing authority
-  github: true
-  # trust the Sigstore public-good signing authority
-  sigstorePublic: true
+  # Identify which signing authorities should be trusted as part of the policy
+  trust:
+    # trust the GitHub signing authority
+    github: true
+    # trust the Sigstore public-good signing authority
+    sigstorePublic: true


### PR DESCRIPTION
Adds a second `Authority` to the default clusterimagepolicy which will allow images which have been signed by PGI Sigstore.

This essentially means that the policy would allow ANY image as long as it had been signed by EITHER the GitHub Fulcio OR the PGI Fulcio.

Either the github or sigstore PGI authorities can be selectively disabled with the `trust.github` and `trust.sigstorePublic` values in the `values.yaml` file.
