### PR TITLE
Add subjectRegExp param, make organization required if not set

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,5 +40,5 @@ jobs:
       - name: Install trust-policies
         run: |
           helm install trust-policies charts/trust-policies \
-            --set policy.enabled=true
+            --set policy.enabled=true \
             --set policy.organization=github

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,3 +41,4 @@ jobs:
         run: |
           helm install trust-policies charts/trust-policies \
             --set policy.enabled=true
+            --set policy.organization=github

--- a/charts/trust-policies/Chart.yaml
+++ b/charts/trust-policies/Chart.yaml
@@ -8,8 +8,8 @@ sources:
 type: application
 
 name: trust-policies
-version: "v0.3.0"
-appVersion: "v0.3.0"
+version: "v0.4.0"
+appVersion: "v0.4.0"
 
 maintainers:
   - name: codysoyland

--- a/charts/trust-policies/templates/_helpers.tpl
+++ b/charts/trust-policies/templates/_helpers.tpl
@@ -1,0 +1,10 @@
+{{/*
+Generate subjectRegExp value
+*/}}
+{{- define "clusterimagepolicy.subjectRegExp" -}}
+{{- if .Values.policy.subjectRegExp -}}
+subjectRegExp: {{- .Values.policy.subjectRegExp -}}
+{{- else -}}
+subjectRegExp: https://github.com/{{ .Values.policy.organization | required "One of policy.organization/policy.subjectRegExp is required" }}/{{ .Values.policy.repository }}/\.github/workflows/.*
+{{- end -}}
+{{- end -}}

--- a/charts/trust-policies/templates/_helpers.tpl
+++ b/charts/trust-policies/templates/_helpers.tpl
@@ -3,7 +3,7 @@ Generate subjectRegExp value
 */}}
 {{- define "clusterimagepolicy.subjectRegExp" -}}
 {{- if .Values.policy.subjectRegExp -}}
-subjectRegExp: {{- .Values.policy.subjectRegExp -}}
+subjectRegExp: {{ .Values.policy.subjectRegExp }}
 {{- else -}}
 subjectRegExp: https://github.com/{{ .Values.policy.organization | required "One of policy.organization/policy.subjectRegExp is required" }}/{{ .Values.policy.repository }}/\.github/workflows/.*
 {{- end -}}

--- a/charts/trust-policies/templates/clusterimagepolicy-github.yaml
+++ b/charts/trust-policies/templates/clusterimagepolicy-github.yaml
@@ -14,7 +14,7 @@ spec:
       url: https://fulcio.githubapp.com
       identities:
       - issuer: https://token.actions.githubusercontent.com
-        subjectRegExp: https://github.com/{{ .Values.policy.organization }}/{{ .Values.policy.repo }}/\.github/workflows/.*
+        {{- include "clusterimagepolicy.subjectRegExp" . | nindent 8 }}
     rfc3161timestamp:
       trustRootRef: github
     signatureFormat: bundle
@@ -26,7 +26,7 @@ spec:
     keyless:
       identities:
       - issuer: https://token.actions.githubusercontent.com
-        subjectRegExp: https://github.com/{{ .Values.policy.organization }}/{{ .Values.policy.repo }}/\.github/workflows/.*
+        {{- include "clusterimagepolicy.subjectRegExp" . | nindent 8 }}
     ctlog:
       url: https://rekor.sigstore.dev
     signatureFormat: bundle

--- a/charts/trust-policies/values.yaml
+++ b/charts/trust-policies/values.yaml
@@ -1,9 +1,11 @@
 # A default policy can be created by setting policy.enabled to true.
 policy:
-  # organization is a regex that matches the organization name in the certificate identity
-  organization: '.*'
-  # repo is a regex that matches the repository name in the certificate identity
-  repo: '.*'
+  # subjectRegExp is a regex that matches the subject in the certificate identity. Required if policy.enabled is true and policy.organization is not set.
+  subjectRegExp:
+  # organization is a regex that matches the organization name in the certificate identity. Required if policy.enabled is true and policy.subjectRegExp is not set.
+  organization:
+  # repository is a regex that matches the repository name in the certificate identity. 
+  repository: '.*'
   # enabled is a flag to enable the default policy
   enabled: false
   # predicateType is the type of predicate to expect in the default policy

--- a/charts/trust-policies/values.yaml
+++ b/charts/trust-policies/values.yaml
@@ -1,6 +1,6 @@
 # A default policy can be created by setting policy.enabled to true.
 policy:
-  # subjectRegExp is a regex that matches the subject in the certificate identity. Required if policy.enabled is true and policy.organization is not set.
+  # subjectRegExp is a regex that is used to validate the signer workflow's identity by matching it with the subject in the certificate identity. Required if policy.enabled is true and policy.organization is not set.
   subjectRegExp:
   # organization is a regex that matches the organization name in the certificate identity. Required if policy.enabled is true and policy.subjectRegExp is not set.
   organization:

--- a/charts/trust-policies/values.yaml
+++ b/charts/trust-policies/values.yaml
@@ -4,7 +4,7 @@ policy:
   subjectRegExp:
   # organization is a regex that matches the organization name in the certificate identity. Required if policy.enabled is true and policy.subjectRegExp is not set.
   organization:
-  # repository is a regex that matches the repository name in the certificate identity. 
+  # repository is a regex that matches the repository name in the certificate identity.
   repository: '.*'
   # enabled is a flag to enable the default policy
   enabled: false

--- a/charts/trust-policies/values.yaml
+++ b/charts/trust-policies/values.yaml
@@ -1,16 +1,22 @@
 # A default policy can be created by setting policy.enabled to true.
 policy:
-  # subjectRegExp is a regex that is used to validate the signer workflow's identity by matching it with the subject in the certificate identity. Required if policy.enabled is true and policy.organization is not set.
-  subjectRegExp:
-  # organization is a regex that matches the organization name in the certificate identity. Required if policy.enabled is true and policy.subjectRegExp is not set.
+  # To verify an attestation, we must validate the identity of the workflow that signed it, which is stored in the attestation's certificate's subject alternative name.
+  # To validate the signer workflow's identity, you can set the subjectRegExp value, or set the organization and the repository values below.
+  #
+  # policy.organization is used to validate the signer workflow's identity. An attestation is valid if it was generated inside a repository owned by this organization.
+  # Required if policy.enabled is true and policy.subjectRegExp has not been set.
   organization:
-  # repository is a regex that matches the repository name in the certificate identity.
+  # policy.repository is used to validate the signer workflow's identity. An attestation is valid if it was generated inside this specific repository.
+  # Must be used in combination with the policy.organization value.
   repository: '.*'
-  # enabled is a flag to enable the default policy
-  enabled: false
-  # predicateType is the type of predicate to expect in the default policy
+  # policy.subjectRegExp is a regex used to validate the signer workflow's identity. Use this if your attestations are generated with a reusable workflow.
+  # Required if policy.enabled is true and policy.organization has not been set.
+  subjectRegExp:
+  # policy.predicateType defines the type of predicate that the default policy expects
   predicateType: https://slsa.dev/provenance/v1
-  # Identify which signing authorities should be trusted as part of the policy
+  # policy.enabled enables the default policy
+  enabled: false
+  # policy.trust identifies which signing authorities should be trusted as part of the policy
   trust:
     # trust the GitHub signing authority
     github: true


### PR DESCRIPTION
- Add subjectRegExp param
- Make organization/subjectRegExp required
- Rename repo to repository

This adds the ability to override the entire `subjectRegExp` (instead of setting repo/org).

This also marks the subject OR organization as a required field. Instead of the org defaulting to `.*`, it must be set unless subjectRegExp is set, or it will error:

```
helm template ./charts/trust-policies --set policy.enabled=true
Error: execution error at (trust-policies/templates/clusterimagepolicy-github.yaml:17:12): One of policy.organization/policy.subjectRegExp is required

Use --debug flag to render out invalid YAML
```



Signed-off-by: Cody Soyland <codysoyland@github.com>