### PR TITLE
Add ability to pass glob patterns to match image, and add "exempt" policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Next, install the GitHub `TrustRoot` and our default `ClusterImagePolicy`:
 helm install trust-policies --atomic \
  --namespace artifact-attestations \
  oci://ghcr.io/github/artifact-attestations-helm-charts/trust-policies \
- --version v0.4.0 \
+ --version v0.5.0 \
  --set policy.enabled=true \
  --set policy.organization=MY-ORGANIZATION
 ```

--- a/charts/trust-policies/Chart.yaml
+++ b/charts/trust-policies/Chart.yaml
@@ -8,8 +8,8 @@ sources:
 type: application
 
 name: trust-policies
-version: "v0.4.0"
-appVersion: "v0.4.0"
+version: "v0.5.0"
+appVersion: "v0.5.0"
 
 maintainers:
   - name: codysoyland

--- a/charts/trust-policies/templates/_helpers.tpl
+++ b/charts/trust-policies/templates/_helpers.tpl
@@ -3,8 +3,18 @@ Generate subjectRegExp value
 */}}
 {{- define "clusterimagepolicy.subjectRegExp" -}}
 {{- if .Values.policy.subjectRegExp -}}
-subjectRegExp: {{ .Values.policy.subjectRegExp }}
+subjectRegExp: "{{ .Values.policy.subjectRegExp }}"
 {{- else -}}
 subjectRegExp: https://github.com/{{ .Values.policy.organization | required "One of policy.organization/policy.subjectRegExp is required" }}/{{ .Values.policy.repository }}/\.github/workflows/.*
 {{- end -}}
+{{- end -}}
+{{- define "clusterimagepolicy.images" -}}
+{{- range .Values.policy.images -}}
+- glob: "{{ . }}"
+{{ end -}}
+{{- end -}}
+{{- define "clusterimagepolicy.exemptImages" -}}
+{{- range .Values.policy.exemptImages -}}
+- glob: "{{ . }}"
+{{ end -}}
 {{- end -}}

--- a/charts/trust-policies/templates/clusterimagepolicy-exempt.yaml
+++ b/charts/trust-policies/templates/clusterimagepolicy-exempt.yaml
@@ -1,0 +1,11 @@
+{{ if and .Values.policy.enabled .Values.policy.exemptImages }}
+apiVersion: policy.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: github-exempt-policy
+spec:
+  images: {{ include "clusterimagepolicy.exemptImages" . | nindent 4  }}
+  authorities:
+    - static:
+        action: pass
+{{- end }}

--- a/charts/trust-policies/templates/clusterimagepolicy-github.yaml
+++ b/charts/trust-policies/templates/clusterimagepolicy-github.yaml
@@ -4,8 +4,7 @@ kind: ClusterImagePolicy
 metadata:
   name: github-policy
 spec:
-  images:
-  - glob: "**"
+  images: {{ include "clusterimagepolicy.images" . | nindent 4  }}
   authorities:
 {{ if .Values.policy.trust.github }}
   - name: github

--- a/charts/trust-policies/values.yaml
+++ b/charts/trust-policies/values.yaml
@@ -14,6 +14,11 @@ policy:
   subjectRegExp:
   # policy.predicateType defines the type of predicate that the default policy expects
   predicateType: https://slsa.dev/provenance/v1
+  # images is a list of image glob patterns that the policy applies to
+  images:
+    - "**"
+  # exemptImages is a list of image glob patterns that will be allowed to run without verification
+  exemptImages: []
   # policy.enabled enables the default policy
   enabled: false
   # policy.trust identifies which signing authorities should be trusted as part of the policy


### PR DESCRIPTION
This PR adds Helm values `policy.images` and `policy.exemptImages` to the `trust-policies` Helm chart. `policy.images` is a list of image glob patterns that the policy applies to, and `policy.exemptImages` is a list of image glob patterns that will be exempt from verification.

Usage:
```bash
helm install trust-policies \
--atomic \
--namespace artifact-attestations \
--version v0.5.0 \
--set policy.enabled=true \
--set policy.images[0]='ghcr.io/my-org/**' \
--set policy.exemptImages[0]="index.docker.io/library/busybox**" \
oci://ghcr.io/github/artifact-attestations-helm-charts/trust-policies
```