### PR TITLE
Tweak `githubTrustDomain` documentation comment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Next, install the GitHub `TrustRoot` and our default `ClusterImagePolicy`:
 helm install trust-policies --atomic \
  --namespace artifact-attestations \
  oci://ghcr.io/github/artifact-attestations-helm-charts/trust-policies \
- --version v0.6.0 \
+ --version v0.6.1 \
  --set policy.enabled=true \
  --set policy.organization=MY-ORGANIZATION
 ```

--- a/charts/trust-policies/Chart.yaml
+++ b/charts/trust-policies/Chart.yaml
@@ -8,8 +8,8 @@ sources:
 type: application
 
 name: trust-policies
-version: "v0.6.0"
-appVersion: "v0.6.0"
+version: "v0.6.1"
+appVersion: "v0.6.1"
 
 maintainers:
   - name: codysoyland

--- a/charts/trust-policies/values.yaml
+++ b/charts/trust-policies/values.yaml
@@ -27,7 +27,7 @@ policy:
     github: true
     # githubTrustDomain is determined by where your GitHub enterprise account is hosted.
     # If your enterprise is on GitHub.com, leave this field blank.
-    # If your enterprise is on GHE.com, then run the following command to find your githubTrustDomain:
+    # If your enterprise is on GHE.com, then githubTrustDomain must be set to the output of the following command:
     # $ gh api meta --jq .domains.artifact_attestations.trust_domain
     # For more information, see: https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/enforcing-artifact-attestations-with-a-kubernetes-admission-controller
     githubTrustDomain: ''

--- a/charts/trust-policies/values.yaml
+++ b/charts/trust-policies/values.yaml
@@ -25,10 +25,11 @@ policy:
   trust:
     # trust the GitHub signing authority
     github: true
-    # githubTrustDomain may be set to the trust domain applicable for some GitHub Enterprise Cloud accounts.
-    # If applicable, this may be set to the output of the following command:
+    # githubTrustDomain is determined by where your GitHub enterprise account is hosted.
+    # If your enterprise is on GitHub.com, leave this field blank.
+    # If your enterprise is on GHE.com, then run the following command to find your githubTrustDomain:
     # $ gh api meta --jq .domains.artifact_attestations.trust_domain
-    # See documentation for more details: https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/enforcing-artifact-attestations-with-a-kubernetes-admission-controller
+    # For more information, see: https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/enforcing-artifact-attestations-with-a-kubernetes-admission-controller
     githubTrustDomain: ''
     # trust the Sigstore public-good signing authority
     sigstorePublic: true


### PR DESCRIPTION
This PR proposes an improvement to the language we use to describe the `githubTrustDomain` field.