### PR TITLE
Bump policy-controller to v0.10.0-github8

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ the [Attest Build Provenance Action](https://github.com/github/artifact-attestat
 You can verify these releases using the [`gh` CLI](https://cli.github.com/manual/gh_attestation_verify):
 ```bash
 gh attestation verify --owner github \
-    oci://ghcr.io/github/artifact-attestations-helm-charts/policy-controller:v0.10.0-github7
+    oci://ghcr.io/github/artifact-attestations-helm-charts/policy-controller:v0.10.0-github8
 ```
 
 For more information, see [our documentation](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds) on using artifact attestations to establish build provenance and [our blog post](https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/) introducing Artifact Attestations.
@@ -26,7 +26,7 @@ You will need to install two charts. First, install the Sigstore policy controll
 helm install policy-controller --atomic \
   --create-namespace --namespace artifact-attestations \
   oci://ghcr.io/github/artifact-attestations-helm-charts/policy-controller \
-  --version v0.10.0-github7
+  --version v0.10.0-github8
 ```
 
 The `--atomic` flag will delete the installation if failure occurs.
@@ -91,8 +91,8 @@ please file an [issue](https://github.com/github/artifact-attestations-helm-char
 When you are ready to cut a new release for a given Helm chart
 
 1. Update the chart's `AppVersion` and `Version` to the appropriate values
-1. Create a new tag prefixed with the targeted chart name in the format <my-chart-name>-v0.1.2, ex: `git tag -s "policy-controller-v0.10.0-github7" -m "policy-controller-v0.10.0-github7"`
-1. Push the tag, ex: `git push origin "policy-controller-v0.10.0-github7"`
+1. Create a new tag prefixed with the targeted chart name in the format <my-chart-name>-v0.1.2, ex: `git tag -s "policy-controller-v0.10.0-github8" -m "policy-controller-v0.10.0-github8"`
+1. Push the tag, ex: `git push origin "policy-controller-v0.10.0-github8"`
 1. The [release workflow](.github/workflows/release.yml) will be triggered if
 the chart's tag format is included in the list of tags that trigger the workflow.
 The tag must follow the format `<my-chart-name>-v<semantic-version>`

--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -8,8 +8,8 @@ sources:
 type: application
 
 name: policy-controller
-version: "v0.10.0-github7"
-appVersion: "v0.10.0-github7"
+version: "v0.10.0-github8"
+appVersion: "v0.10.0-github8"
 
 maintainers:
   - name: codysoyland

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -16,8 +16,8 @@ webhook:
   name: webhook
   image:
     repository: ghcr.io/github/policy-controller-webhook
-    # crane digest ghcr.io/github/policy-controller-webhook:v0.10.0-github7
-    version: sha256:0bc1630678ffb1623c139d6f0cfdb512a2041033ec94c83a3820f7eddd6b0aab
+    # crane digest ghcr.io/github/policy-controller-webhook:v0.10.0-github8
+    version: sha256:2f8369a686cb28e86403768a7114396aa7aa3565340c8e8d1c1d94d3c69b341b
     pullPolicy: IfNotPresent
   env: {}
   extraArgs: {}
@@ -71,7 +71,7 @@ leasescleanup:
   image:
     repository: cgr.dev/chainguard/kubectl
     # crane digest cgr.dev/chainguard/kubectl:latest
-    version: sha256:dfa420c3fe94a8365b274fd714fb829b466cd762d6870d579db8744e6f27450a
+    version: sha256:12a6dcc2bbacbf6114ea9ea54127b9487f469fac1b5ff0b8b19643eeffe45269
     pullPolicy: IfNotPresent
 
 ## common node selector for all the pods


### PR DESCRIPTION
This release includes a fix for a blocking call in the azidentity library that prevents admission in some cloud environments. A detailed description of this bug can be found in the upstream repo [here](https://github.com/sigstore/policy-controller/issues/1657).

Fixes https://github.com/github/artifact-attestations-helm-charts/issues/53