### PR TITLE
fix: add missing keyless.url for public-good

### DIFF
--- a/charts/trust-policies/Chart.yaml
+++ b/charts/trust-policies/Chart.yaml
@@ -8,8 +8,8 @@ sources:
 type: application
 
 name: trust-policies
-version: "v0.6.1"
-appVersion: "v0.6.1"
+version: "v0.6.2"
+appVersion: "v0.6.2"
 
 maintainers:
   - name: codysoyland

--- a/charts/trust-policies/templates/clusterimagepolicy-github.yaml
+++ b/charts/trust-policies/templates/clusterimagepolicy-github.yaml
@@ -26,6 +26,7 @@ spec:
       identities:
       - issuer: https://token.actions.githubusercontent.com
         {{- include "clusterimagepolicy.subjectRegExp" . | nindent 8 }}
+      url: https://fulcio.sigstore.dev
     ctlog:
       url: https://rekor.sigstore.dev
     signatureFormat: bundle


### PR DESCRIPTION
This resolves issue #67 

Proof of test:

This is the resulting desired manifest produced by the helm chart:

![image](https://github.com/user-attachments/assets/514aee0d-3ca0-4ef2-87ac-a10dcbb9cd06)


It now shows no diff with the live manifest, and thus ArgoCD considers it in sync!

![image](https://github.com/user-attachments/assets/270c9102-8bbe-449a-a23b-027e09a9860f)
