### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,7 @@ on:
     paths:
       - "charts/**"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "charts/**"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/github/artifact-attestations-helm-charts/security/code-scanning/1](https://github.com/github/artifact-attestations-helm-charts/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly define the minimal permissions required for the workflow. ~~Based on the provided workflow, the actions primarily involve reading repository contents (e.g., checking out code) and do not appear to require write permissions. Therefore, we will set `contents: read` as the minimal permission.~~

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

Copilot suggested `contents: read` but I don't believe any permissions are appropriate. So assigning no permissions.
